### PR TITLE
Feat: API collector automation

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,0 +1,8 @@
+go/golang/github.com%2Fgoogle%2Fgo-github/v61/v61.0.0, BSD-3-Clause, approved, #14664
+go/golang/github.com%2Fgoogle/go-cmp/v0.5.2, BSD-3-Clause, approved, #5689
+go/golang/github.com%2Fgoogle/go-cmp/v0.6.0, BSD-3-Clause, approved, #11058
+go/golang/github.com%2Fgoogle/go-querystring/v1.1.0, BSD-3-Clause, approved, clearlydefined
+go/golang/golang.org%2Fx/oauth2/v0.20.0, BSD-3-Clause, approved, clearlydefined
+go/golang/golang.org%2Fx/xerrors/v0.0.0-20191204190536-9bdfabe68543, BSD-3-Clause, approved, #3443
+go/golang/gopkg.in/check.v1/v0.0.0-20161208181325-20d25e280405, BSD-3-Clause AND BSD-2-Clause, approved, #6054
+go/golang/gopkg.in/yaml.v2/v2.4.0, Apache-2.0 AND MIT, approved, #6057

--- a/src/api-collector/go.mod
+++ b/src/api-collector/go.mod
@@ -1,0 +1,3 @@
+module api-collector
+
+go 1.21.6

--- a/src/api-collector/go.mod
+++ b/src/api-collector/go.mod
@@ -1,3 +1,11 @@
 module api-collector
 
 go 1.21.6
+
+require (
+	github.com/google/go-github/v61 v61.0.0
+	golang.org/x/oauth2 v0.20.0
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require github.com/google/go-querystring v1.1.0 // indirect

--- a/src/api-collector/go.sum
+++ b/src/api-collector/go.sum
@@ -1,0 +1,14 @@
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5pNlu1go=
+github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/oauth2 v0.20.0 h1:4mQdhULixXKP1rwYBW0vAijoXnkTG0BLCDRzfe1idMo=
+golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -127,7 +127,7 @@ func getAPISpecAssets(ctx context.Context, client *github.Client, owner string, 
 		return apiSpecs
 	}
 	for _, asset := range assets {
-		if strings.Contains(*asset.Name, "openapi.yaml") {
+		if strings.Contains(*asset.Name, "_openapi.yaml") || strings.Contains(*asset.Name, "_openapi.yml") {
 			apiSpecs = append(apiSpecs, assetInfo{*asset.ID, *asset.Name})
 		}
 	}

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+ package main
+
+
+func main() {
+}

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -51,6 +51,13 @@ type OpenAPISpec struct {
 	Info    OpenAPIInfo `yaml:"info"`
 }
 
+const MetadataFilename = ".tractusx"
+
+type Metadata struct {
+	ProductName  string   `yaml:"product"`
+	OpenApiSpecs []string `yaml:"openApiSpecs"`
+}
+
 func main() {
 	owner, token := getArgs()
 	ctx := context.Background()
@@ -69,6 +76,18 @@ func main() {
 		downloadedSpecs := downloadAPISpecs(ctx, client, owner, *repo.Name, specAssets)
 		commitDownloadedSpec(ctx, client, owner, API_DOCS_REPO, downloadedSpecs)
 	}
+}
+
+func MetadataFromFile(fileContent []byte) (*Metadata, error) {
+	var metadata Metadata
+
+	err := yaml.Unmarshal(fileContent, &metadata)
+	if err != nil {
+		fmt.Println("Error parsing product metadata file")
+		return nil, err
+	}
+
+	return &metadata, nil
 }
 
 func getArgs() (string, string) {

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -17,8 +17,28 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
- package main
+package main
 
+import (
+	"flag"
+	"fmt"
+	"os"
+)
 
 func main() {
+	owner, token := getArgs()
+	fmt.Println(owner, token)
+}
+
+func getArgs() (string, string) {
+
+	owner := flag.String("owner", "", "Specify GitHub User or Organization")
+	token := flag.String("token", "", "Specify GitHub Token")
+	flag.Parse()
+
+	if *owner == "" || *token == "" {
+		fmt.Println("Missing required arguments, please specify -owner [owner] and -token [token]")
+		os.Exit(1)
+	}
+	return *owner, *token
 }

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -30,7 +30,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/google/go-github/v48/github"
+	"github.com/google/go-github/v61/github"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v2"
 )
@@ -73,7 +73,6 @@ func main() {
 }
 
 func getArgs() (string, string) {
-
 	owner := flag.String("owner", "", "Specify GitHub User or Organization")
 	token := flag.String("token", "", "Specify GitHub Token")
 	flag.Parse()

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -37,11 +37,6 @@ import (
 
 const API_DOCS_REPO = "api-hub"
 
-type assetInfo struct {
-	id   int64
-	name string
-}
-
 type OpenAPIInfo struct {
 	Version string `yaml:"version"`
 	Title   string `yaml:"title"`
@@ -153,27 +148,6 @@ func getAPISpecsUrls(ctx context.Context, client *github.Client, owner string, r
 		return nil, fmt.Errorf("error parsing metadata: %v", err)
 	}
 	return m.OpenApiSpecs, nil
-}
-
-func getAPISpecAssets(ctx context.Context, client *github.Client, owner string, repo string) []assetInfo {
-	var apiSpecs []assetInfo
-	release, _, err := client.Repositories.GetLatestRelease(ctx, owner, repo)
-	if err != nil {
-		log.Println("\t- No release found")
-		return apiSpecs
-	}
-	log.Printf("\t+ Latest release found: %s\n", *release.Name)
-	assets, _, err := client.Repositories.ListReleaseAssets(ctx, owner, repo, *release.ID, nil)
-	if err != nil {
-		log.Println("\t- No assets found in the release")
-		return apiSpecs
-	}
-	for _, asset := range assets {
-		if strings.Contains(*asset.Name, "_openapi.yaml") || strings.Contains(*asset.Name, "_openapi.yml") {
-			apiSpecs = append(apiSpecs, assetInfo{*asset.ID, *asset.Name})
-		}
-	}
-	return apiSpecs
 }
 
 func downloadAPISpecs(repo string, specsUrls []string) []string {

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -67,7 +67,7 @@ func main() {
 			continue
 		}
 		downloadedSpecs := downloadAPISpecs(ctx, client, owner, *repo.Name, specAssets)
-		uploadAPISpecs(ctx, client, owner, API_DOCS_REPO, downloadedSpecs)
+		commitDownloadedSpec(ctx, client, owner, API_DOCS_REPO, downloadedSpecs)
 	}
 }
 
@@ -185,7 +185,7 @@ func downloadAPISpecs(ctx context.Context, client *github.Client, owner string, 
 	return downloadedSpecs
 }
 
-func uploadAPISpecs(ctx context.Context, client *github.Client, owner string, repo string, specs []string) {
+func commitDownloadedSpec(ctx context.Context, client *github.Client, owner string, repo string, specs []string) {
 	for _, spec := range specs {
 		content, err := os.ReadFile(spec)
 		if err != nil {

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -58,7 +58,6 @@ func main() {
 	repos, err := getOrgRepos(ctx, owner, client)
 	if err != nil {
 		log.Fatalf("Error fetching repos: %s", err)
-		os.Exit(1)
 	}
 	for _, repo := range repos {
 		log.Println("Scanning repo ", *repo.Name)
@@ -78,8 +77,7 @@ func getArgs() (string, string) {
 	flag.Parse()
 
 	if *owner == "" || *token == "" {
-		fmt.Println("Missing required arguments, please specify -owner [owner] and -token [token]")
-		os.Exit(1)
+		log.Fatalln("Missing required arguments, please specify -owner [owner] and -token [token]")
 	}
 	return *owner, *token
 }

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -132,6 +132,24 @@ func getOrgRepos(ctx context.Context, gitOwner string, client *github.Client) ([
 	return allRepos, nil
 }
 
+func getAPISpecsUrls(ctx context.Context, client *github.Client, owner string, repo string) ([]string, error) {
+	metadataFile, _, _, err := client.Repositories.GetContents(ctx, owner, repo, MetadataFilename, &github.RepositoryContentGetOptions{
+		Ref: "main",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error getting .tractusx metadata file: %v", err)
+	}
+	content, err := metadataFile.GetContent()
+	if err != nil {
+		return nil, fmt.Errorf("error getting metadata content: %v", err)
+	}
+	m, err := MetadataFromFile([]byte(content))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing metadata: %v", err)
+	}
+	return m.OpenApiSpecs, nil
+}
+
 func getAPISpecAssets(ctx context.Context, client *github.Client, owner string, repo string) []assetInfo {
 	var apiSpecs []assetInfo
 	release, _, err := client.Repositories.GetLatestRelease(ctx, owner, repo)


### PR DESCRIPTION
PR is introducting a subcomponent of automation responsible for collecting OpenAPI specs across organization (currently default to Tractus-X) following specific naming convention productname_openapi.{yml, yaml} and storing it within api-hub repository under docs folder. Downloaded assets will be used by workflow to generate Swagger UI and published at GitHub Pages for easy access. 

Updates https://github.com/eclipse-tractusx/sig-infra/issues/376

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
