### PR TITLE
fix: api publish workflow

### DIFF
--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Check for specs
         id: check_specs
         run: |
-          if [ -d "docs" ]; then
+          if [ -d "${{ env.API_COLLECTOR_DIR }}/docs" ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "exists=false" >> $GITHUB_OUTPUT
@@ -56,7 +56,7 @@ jobs:
         if: steps.check_specs.outputs.exists == 'true'
         with:
           name: openapi-${{ steps.collect_specs.outputs.RANDOM }}
-          path: docs
+          path: ${{ env.API_COLLECTOR_DIR }}/docs
   generate_matrix:
     runs-on: ubuntu-latest
     needs: collect_openapi
@@ -83,6 +83,12 @@ jobs:
       matrix: ${{ fromJson(needs.generate_matrix.outputs.specs) }}
     steps:
       - uses: actions/checkout@v4
+      - name: Download OpenAPI specs artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: docs
+          pattern: openapi-*
+          merge-multiple: true
       - name: Determine spec file directory
         id: determine_directory
         run: |

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -25,6 +25,7 @@ on:
     - cron: "0 4 * * *"
 
 env:
+  # API collector and specs download "docs" path
   API_COLLECTOR_DIR: "src/api-collector"
 
 jobs:

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -75,8 +75,8 @@ func main() {
 
 		downloadedSpecs := downloadAPISpecs(*repo.Name, specsUrls)
 		log.Println("List of downloaded OpenAPI specs:")
-		for downloadedSpec := range downloadedSpecs {
-			log.Println("- ",downloadedSpec)
+		for _, downloadedSpec := range downloadedSpecs {
+			log.Printf("- %s\n",downloadedSpec)
 		}
 	}
 }


### PR DESCRIPTION
## Description
Fix for incorrect "docs" location in the Publish API workflow and missing artefacts download in respective job.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
