### PR TITLE
feat: Generate index for API gh pages

### DIFF
--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -123,6 +123,10 @@ jobs:
           path: docs
           pattern: swagger-*
           merge-multiple: true
+      - name: Generate Directory Listings
+        uses: jayanta525/github-pages-directory-listing@v4.0.0
+        with:
+          FOLDER: docs
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -95,14 +95,20 @@ jobs:
         run: |
           FILE_PATH="${{ matrix.specs }}"
           DIR_PATH=$(dirname "${FILE_PATH}")
+          PRODUCT_PATH=${dirname "${DIR_PATH}"}
           RANDOM=$(uuidgen)
           echo "DIR_PATH=${DIR_PATH}" >> $GITHUB_OUTPUT
+          echo "PRODUCT_PATH=${PRODUCT_PATH}" >> $GITHUB_OUTPUT
           echo "RANDOM=${RANDOM}" >> $GITHUB_OUTPUT
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:
           output: ${{ steps.determine_directory.outputs.DIR_PATH }}/swagger-ui
           spec-file: ${{ matrix.specs }}
+      - name: Generate Directory Listings
+        uses: jayanta525/github-pages-directory-listing@v4.0.0
+        with:
+          FOLDER: ${{ steps.determine_directory.outputs.PRODUCT_PATH }}
       - uses: actions/upload-artifact@v4
         with:
           name: swagger-${{ steps.determine_directory.outputs.RANDOM }}

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -95,7 +95,7 @@ jobs:
         run: |
           FILE_PATH="${{ matrix.specs }}"
           DIR_PATH=$(dirname "${FILE_PATH}")
-          PRODUCT_PATH=${dirname "${DIR_PATH}"}
+          PRODUCT_PATH=$(dirname "${DIR_PATH}")
           RANDOM=$(uuidgen)
           echo "DIR_PATH=${DIR_PATH}" >> $GITHUB_OUTPUT
           echo "PRODUCT_PATH=${PRODUCT_PATH}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description
PR to enable/generate index for directories/files listing on API Github pages. It allows the viewer to list/navigate to available API docs.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
