### PR TITLE
feat: conventional API collection approach

### DIFF
--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -35,8 +35,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const API_DOCS_REPO = "api-hub"
-
+const (
+	API_DOCS_REPO = "api-hub"
+	API_SPEC_PATH = "/docs/api/openAPI.yaml"
+)
 type OpenAPIInfo struct {
 	Version string `yaml:"version"`
 	Title   string `yaml:"title"`
@@ -198,3 +200,13 @@ func downloadAPISpecs(repo string, specsUrls []string) []string {
 	return downloadedSpecs
 }
 
+func getAPISpecFromDir(ctx context.Context, client *github.Client, owner string, repo string) ([]byte, error) {
+    apiContent, _, _, err := client.Repositories.GetContents(ctx, owner, repo, API_SPEC_PATH, &github.RepositoryContentGetOptions{
+        Ref: "main",
+    })
+    if err != nil {
+        return []byte{}, fmt.Errorf("error getting file content: %v", err)
+    }
+	content, err := apiContent.GetContent()
+	return []byte(content), err
+}

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -130,7 +130,7 @@ func getOrgRepos(ctx context.Context, gitOwner string, client *github.Client) ([
 	return allRepos, nil
 }
 
-func getAPISpecsUrls(ctx context.Context, client *github.Client, owner string, repo string) ([]string, error) {
+func getAPISpecsUrlsFromMetadata(ctx context.Context, client *github.Client, owner string, repo string) ([]string, error) {
 	metadataFile, _, _, err := client.Repositories.GetContents(ctx, owner, repo, MetadataFilename, &github.RepositoryContentGetOptions{
 		Ref: "main",
 	})
@@ -159,7 +159,7 @@ func downloadAPISpecs(ctx context.Context, client *github.Client, owner string, 
 	}
 	log.Printf("OpenAPI specs not found in the default location docs/api/openAPI.yaml. Proceeding with .tractusx metadata.")
 	var downloadedSpecs []string
-	specsUrls, err := getAPISpecsUrls(ctx, client, owner, repo)
+	specsUrls, err := getAPISpecsUrlsFromMetadata(ctx, client, owner, repo)
 	if err != nil {
 		log.Printf("%v\n", err)
 	}

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -210,3 +210,21 @@ func getAPISpecFromDir(ctx context.Context, client *github.Client, owner string,
 	content, err := apiContent.GetContent()
 	return []byte(content), err
 }
+
+func getAPISpecFromUrl(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return []byte{}, fmt.Errorf("error downloading API spec file: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return []byte{}, fmt.Errorf("bad HTTP status: %s", resp.Status)
+
+	}
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return []byte{}, fmt.Errorf("error reading HTTP response: %v", err)
+	}
+	return content, nil
+}

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -28,7 +28,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/google/go-github/v61/github"
 	"golang.org/x/oauth2"
@@ -65,20 +64,14 @@ func main() {
 	}
 	for _, repo := range repos {
 		log.Println("Scanning repo ", *repo.Name)
-		specsUrls, err := getAPISpecsUrls(ctx, client, owner, *repo.Name)
-		if err != nil {
-			log.Println(err)
-			continue
-		}
-		if specsUrls == nil {
-			log.Println("No OpenAPI specs found")
-			continue
-		}
-
-		downloadedSpecs := downloadAPISpecs(*repo.Name, specsUrls)
-		log.Println("List of downloaded OpenAPI specs:")
-		for _, downloadedSpec := range downloadedSpecs {
-			log.Printf("- %s\n",downloadedSpec)
+		downloadedSpecs := downloadAPISpecs(ctx, client, owner, *repo.Name)
+		if len(downloadedSpecs) > 0 {
+			log.Println("List of downloaded OpenAPI specs:")
+			for _, downloadedSpec := range downloadedSpecs {
+				log.Printf("- %s\n",downloadedSpec)
+			}
+		} else {
+			log.Printf("No OpenAPI specs found in .tractusx metadata.")
 		}
 	}
 }

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -228,3 +228,22 @@ func getAPISpecFromUrl(url string) ([]byte, error) {
 	}
 	return content, nil
 }
+
+func saveAPISpec(content []byte, repo string) (string, error)  {
+	var spec OpenAPISpec
+	err := yaml.Unmarshal([]byte(content), &spec)
+	if err != nil {
+		return "", fmt.Errorf("error parsing OpenAPI spec yaml format: %v", err)
+	}
+	dirPath := path.Join("docs", repo, spec.Info.Version)
+	err = os.MkdirAll(dirPath, os.ModePerm)
+	if err != nil {
+		return "", fmt.Errorf("error creating directory: %v", err)
+	}
+	filePath := path.Join(dirPath, "openAPI.yaml")
+	err = os.WriteFile(filePath, content, 0644)
+	if err != nil {
+		return "", fmt.Errorf("error saving OpenAPI spec content to file: %v", err)
+	}
+	return filePath, nil
+}


### PR DESCRIPTION
## Description

PR introducing conventional approach of OpenAPI specification collection in addition to currently available configuration via .tractusx metadata. 

Convention assumes existance of OpenAPI specification file "openAPI.yaml" stored in docs/api repository directory.

updates https://github.com/eclipse-tractusx/sig-infra/issues/376

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
