### PR TITLE
feat: enhancement for kits

### DIFF
--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -173,7 +173,6 @@ func downloadAPISpecs(ctx context.Context, client *github.Client, owner string, 
 			continue
 		}
 		downloadedSpecs = append(downloadedSpecs, specPath)
-		log.Printf("OpenAPI spec saved successfully\n", specPath)
 	}
 	return downloadedSpecs
 }


### PR DESCRIPTION

## Description
Enhancement to current automation adding a KITs API collection logic. 


1. KITs API spec would follow configuration method, meaning you add each OpenAPI spec in the .tractusx metadata file as TRG states. No need to move files to /docs/api folder in repo.
2. KITs OpenAPI spec filenames need to follow special naming convention “kit_nameofthekit_openAPI.yaml”. The only part which you change is “nameofthekit”, you change it as you like the only caveat is to not use “_” underscore in that name.
3. Your Swagger UI docs would be available at following URL: [https://eclipse-tractusx.github.io/api-hub/reponame/kit-nameofthekit-version/swagger-ui/]


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
