### PR TITLE
feat: enable multiple api specs for each product

### DIFF
--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -45,6 +45,28 @@ jobs:
           echo "RANDOM=${RANDOM}" >> $GITHUB_OUTPUT
           cd ${{ env.API_COLLECTOR_DIR }}
           go run main.go -owner ${{ github.repository_owner }} -token ${{ secrets.GITHUB_TOKEN }}
+      - name: Move multiple OpenAPI specs files in one directory into individual directories
+        run: |
+          # Find all directories containing multiple *.yaml or *.yml files
+          find "${{ env.API_COLLECTOR_DIR }}/docs" -type d | while read -r DIR; do
+            # Count how many YAML/YML files are in the current directory
+            FILES=($(find "$DIR" -maxdepth 1 -type f \( -name "*.yaml" -o -name "*.yml" \)))
+            # If there are more than one YAML file in the directory
+            if [ ${#FILES[@]} -gt 1 ]; then
+              # Loop through each YAML file
+              for FILE in "${FILES[@]}"; do
+                # Extract the filename without the extension
+                FILENAME=$(basename "$FILE")
+                BASENAME="${FILENAME%.*}"
+                # Create a directory named after the file (without the extension)
+                TARGET_DIR="$DIR/$BASENAME"
+                mkdir -p "$TARGET_DIR"
+                # Move the file into the newly created directory
+                mv "$FILE" "$TARGET_DIR/"
+              done
+            fi
+          done
+          echo "Multiple OpenAPI specs files in one directory have been organized into individual directories."
       - name: Check for specs
         id: check_specs
         run: |
@@ -108,7 +130,7 @@ jobs:
       - name: Generate Directory Listings
         uses: jayanta525/github-pages-directory-listing@v4.0.0
         with:
-          FOLDER: ${{ steps.determine_directory.outputs.PRODUCT_PATH }}
+          FOLDER: ${{ steps.determine_directory.outputs.DIR_PATH }}
       - uses: actions/upload-artifact@v4
         with:
           name: swagger-${{ steps.determine_directory.outputs.RANDOM }}


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

- add script to move multiple OpenAPI specs files in one directory into individual directories
- change to directory path for listing of directories in index.html to enable directory listings also in those individual directories

### Why

https://github.com/eclipse-tractusx/api-hub/issues/20

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] Change was successfully tested --> for products that don't provide multiple api specs, the behaviour of the api hub remains unchanged
