### PR TITLE
Update: Keep older API versions in the hub

### DIFF
--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -155,3 +155,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs
+          keep_files: true


### PR DESCRIPTION
## Description

Currently, the API hub re-generates all swagger documentations with the newest referenced version, while older versions are deleted. This is a problem for the eclipse-tractusx.github repository. In this repository, or more, in the KIT documentation we often need to provide different versions of the API as there are multiple releases (currently e.g. 24.08, 24.12 and next). As a result, we need to provide up to 3 different API versions which need to be referenced by the respective KIT.

*What does this PR introduce?*
This PR adds the `keep_files: true` flag to the publish_api.yaml, which allows to add new API versions without deleting the older ones. We tested this feature exhaustively and it worked perfectly fine, in accordance to the stated requirement.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
