### PR TITLE
fix(swagger-ui-version): add swagger ui version to support openapi 3.1

### DIFF
--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -128,6 +128,7 @@ jobs:
           output: ${{ steps.determine_directory.outputs.DIR_PATH }}/swagger-ui
           spec-file: ${{ matrix.specs }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version: "5.21.0"
       - name: Generate Directory Listings
         uses: jayanta525/github-pages-directory-listing@v4.0.0
         with:


### PR DESCRIPTION
## Description

The swagger-ui version 5.21.0 is the latest which was released and [supports](https://github.com/swagger-api/swagger-ui#compatibility) different OpenAI versions. Including 3.1.0 and older.

Since the [action allows the property](https://github.com/Legion2/swagger-ui-action/blob/main/action.yml#L8) to select the swagger-ui version ... this looks good for me. :) [Currently we are using 3.5](https://github.com/eclipse-tractusx/api-hub/actions/runs/14656706423/job/41132993770#step:6:19)

My assumption would be, that this Fixes #31, i tested it as much as it was possible for me -> [results](https://github.com/eclipse-tractusx/api-hub/issues/31#issuecomment-2835206861)

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
