### PR TITLE
chore(dash-tool): add dash tool action

### DIFF
--- a/.github/workflows/dash-licence-check.yaml
+++ b/.github/workflows/dash-licence-check.yaml
@@ -1,0 +1,41 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+
+name: "3rd Party Dependency Check (Eclipse Dash Tool)"
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  check-3rd-party-licences:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build dash input
+        run: run: cp src/api-collector/go.sum dash-input.sum
+      - name: Run dash
+        id: run-dash
+        uses: eclipse-tractusx/sig-infra/.github/actions/run-dash@main
+        with:
+          dash_input: "dash-input.sum"

--- a/.github/workflows/dash-licence-check.yaml
+++ b/.github/workflows/dash-licence-check.yaml
@@ -1,5 +1,5 @@
 # #############################################################################
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -39,3 +39,4 @@ jobs:
         uses: eclipse-tractusx/sig-infra/.github/actions/run-dash@main
         with:
           dash_input: "dash-input.sum"
+          

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -2,7 +2,7 @@ go/golang/github.com%2Fgoogle%2Fgo-github/v61/v61.0.0, BSD-3-Clause, approved, #
 go/golang/github.com%2Fgoogle/go-cmp/v0.5.2, BSD-3-Clause, approved, #5689
 go/golang/github.com%2Fgoogle/go-cmp/v0.6.0, BSD-3-Clause, approved, #11058
 go/golang/github.com%2Fgoogle/go-querystring/v1.1.0, BSD-3-Clause, approved, clearlydefined
-go/golang/golang.org%2Fx/oauth2/v0.21.0, BSD-3-Clause, approved, clearlydefined
+go/golang/golang.org%2Fx/oauth2/v0.27.0, BSD-3-Clause, approved, clearlydefined
 go/golang/golang.org%2Fx/xerrors/v0.0.0-20191204190536-9bdfabe68543, BSD-3-Clause, approved, #3443
 go/golang/gopkg.in/check.v1/v0.0.0-20161208181325-20d25e280405, BSD-3-Clause AND BSD-2-Clause, approved, #6054
 go/golang/gopkg.in/yaml.v2/v2.4.0, Apache-2.0 AND MIT, approved, #6057


### PR DESCRIPTION
## Description

This PR adds the dash tool action to this repository, since we are using go inside the repository.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
