### PR TITLE
fix(dashtool): Fix syntax error in dash-licence-check.yaml

### DIFF
--- a/.github/workflows/dash-licence-check.yaml
+++ b/.github/workflows/dash-licence-check.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build dash input
-        run: run: cp src/api-collector/go.sum dash-input.sum
+        run: cp src/api-collector/go.sum dash-input.sum
       - name: Run dash
         id: run-dash
         uses: eclipse-tractusx/sig-infra/.github/actions/run-dash@main


### PR DESCRIPTION

## Description

This pull request makes a minor fix to the GitHub Actions workflow for the Dash license check. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
