### PR TITLE
chore(migrate-action-version): migrate checkout version

### DIFF
--- a/.github/workflows/dash-licence-check.yaml
+++ b/.github/workflows/dash-licence-check.yaml
@@ -1,0 +1,42 @@
+# #############################################################################
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+
+name: "3rd Party Dependency Check (Eclipse Dash Tool)"
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  check-3rd-party-licences:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Build dash input
+        run: cp src/api-collector/go.sum dash-input.sum
+      - name: Run dash
+        id: run-dash
+        uses: eclipse-tractusx/sig-infra/.github/actions/run-dash@main
+        with:
+          dash_input: "dash-input.sum"
+          

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -155,3 +155,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs
+          keep_files: true

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -128,6 +128,7 @@ jobs:
           output: ${{ steps.determine_directory.outputs.DIR_PATH }}/swagger-ui
           spec-file: ${{ matrix.specs }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version: "5.21.0"
       - name: Generate Directory Listings
         uses: jayanta525/github-pages-directory-listing@v4.0.0
         with:

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -44,7 +44,7 @@ jobs:
           RANDOM=$(uuidgen)
           echo "RANDOM=${RANDOM}" >> $GITHUB_OUTPUT
           cd ${{ env.API_COLLECTOR_DIR }}
-          go run main.go -owner ${{ github.repository_owner }} -token ${{ secrets.GITHUB_TOKEN }}
+          go run main.go -owner ${{ github.actor }} -token ${{ secrets.GITHUB_TOKEN }}
       - name: Move multiple OpenAPI specs files in one directory into individual directories
         run: |
           # Find all directories containing multiple *.yaml or *.yml files

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -44,7 +44,7 @@ jobs:
           RANDOM=$(uuidgen)
           echo "RANDOM=${RANDOM}" >> $GITHUB_OUTPUT
           cd ${{ env.API_COLLECTOR_DIR }}
-          go run main.go -owner "eclipse-tractusx" -token ${{ secrets.GITHUB_TOKEN }}
+          go run main.go -owner ${{ github.repository_owner }} -token ${{ secrets.GITHUB_TOKEN }}
       - name: Move multiple OpenAPI specs files in one directory into individual directories
         run: |
           # Find all directories containing multiple *.yaml or *.yml files

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -44,7 +44,7 @@ jobs:
           RANDOM=$(uuidgen)
           echo "RANDOM=${RANDOM}" >> $GITHUB_OUTPUT
           cd ${{ env.API_COLLECTOR_DIR }}
-          go run main.go -owner ${{ github.actor }} -token ${{ secrets.GITHUB_TOKEN }}
+          go run main.go -owner ${{ github.repository_owner }} -token ${{ secrets.GITHUB_TOKEN }}
       - name: Move multiple OpenAPI specs files in one directory into individual directories
         run: |
           # Find all directories containing multiple *.yaml or *.yml files

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -44,7 +44,7 @@ jobs:
           RANDOM=$(uuidgen)
           echo "RANDOM=${RANDOM}" >> $GITHUB_OUTPUT
           cd ${{ env.API_COLLECTOR_DIR }}
-          go run main.go -owner ${{ github.repository_owner }} -token ${{ secrets.GITHUB_TOKEN }}
+          go run main.go -owner "eclipse-tractusx" -token ${{ secrets.GITHUB_TOKEN }}
       - name: Move multiple OpenAPI specs files in one directory into individual directories
         run: |
           # Find all directories containing multiple *.yaml or *.yml files

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -34,8 +34,8 @@ jobs:
     outputs:
       specs_exists: ${{ steps.check_specs.outputs.exists }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "${{ env.API_COLLECTOR_DIR }}/go.mod"
       - name: Collect OpenAPI specs
@@ -75,7 +75,7 @@ jobs:
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check_specs.outputs.exists == 'true'
         with:
           name: openapi-${{ steps.collect_specs.outputs.RANDOM }}
@@ -87,9 +87,9 @@ jobs:
     outputs:
       specs: ${{ steps.create_specs_list.outputs.matrix }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download OpenAPI specs artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: docs
           pattern: openapi-*
@@ -105,9 +105,9 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.generate_matrix.outputs.specs) }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download OpenAPI specs artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: docs
           pattern: openapi-*
@@ -133,16 +133,18 @@ jobs:
         uses: jayanta525/github-pages-directory-listing@v4.0.0
         with:
           FOLDER: ${{ steps.determine_directory.outputs.DIR_PATH }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: swagger-${{ steps.determine_directory.outputs.RANDOM }}
           path: docs
   deploy_swagger_ui:
     needs: generate_swagger_ui
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: docs
           pattern: swagger-*
@@ -155,5 +157,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
           publish_dir: docs
-          keep_files: true

--- a/.github/workflows/publish_api.yaml
+++ b/.github/workflows/publish_api.yaml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       specs_exists: ${{ steps.check_specs.outputs.exists }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@v5
         with:
           go-version-file: "${{ env.API_COLLECTOR_DIR }}/go.mod"
@@ -87,7 +87,7 @@ jobs:
     outputs:
       specs: ${{ steps.create_specs_list.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download OpenAPI specs artifacts
         uses: actions/download-artifact@v4
         with:
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.generate_matrix.outputs.specs) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download OpenAPI specs artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -42,13 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Ensure full clone for pull request workflows
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@7e78ca385fb82c19568c7a4b341c97d57d9aa5e1
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26
         continue-on-error: true
         with:
           path: ./  # Scan the entire repository

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0  # Ensure full clone for pull request workflows
 

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -111,9 +111,9 @@ func getAuthenticatedClient(ctx context.Context, gitToken string) *github.Client
 }
 
 func getOrgRepos(ctx context.Context, gitOwner string, client *github.Client) ([]*github.Repository, error) {
-	opt := &github.RepositoryListByOrgOptions{
-		ListOptions: github.ListOptions{},
-	}
+	opt := &github.RepositoryListOptions{
+        Type: "owner", // Can also be "all" or "public"
+    }
 
 	var allRepos []*github.Repository
 

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -111,25 +111,25 @@ func getAuthenticatedClient(ctx context.Context, gitToken string) *github.Client
 }
 
 func getOrgRepos(ctx context.Context, gitOwner string, client *github.Client) ([]*github.Repository, error) {
-	opt := &github.RepositoryListByOrgOptions{
-		ListOptions: github.ListOptions{},
-	}
+    opt := &github.RepositoryListOptions{
+        ListOptions: github.ListOptions{},
+    }
 
-	var allRepos []*github.Repository
+    var allRepos []*github.Repository
 
-	for {
-		repos, response, err := client.Repositories.ListByOrg(ctx, gitOwner, opt)
-		if err != nil {
-			return nil, err
-		}
-		allRepos = append(allRepos, repos...)
-		if response.NextPage == 0 {
-			break
-		}
-		opt.Page = response.NextPage
-	}
+    for {
+        repos, response, err := client.Repositories.List(ctx, gitOwner, opt)
+        if err != nil {
+            return nil, err
+        }
+        allRepos = append(allRepos, repos...)
+        if response.NextPage == 0 {
+            break
+        }
+        opt.Page = response.NextPage
+    }
 
-	return allRepos, nil
+    return allRepos, nil
 }
 
 func getAPISpecsUrlsFromMetadata(ctx context.Context, client *github.Client, owner string, repo string) ([]string, error) {

--- a/src/api-collector/main.go
+++ b/src/api-collector/main.go
@@ -111,9 +111,9 @@ func getAuthenticatedClient(ctx context.Context, gitToken string) *github.Client
 }
 
 func getOrgRepos(ctx context.Context, gitOwner string, client *github.Client) ([]*github.Repository, error) {
-	opt := &github.RepositoryListOptions{
-        Type: "owner", // Can also be "all" or "public"
-    }
+	opt := &github.RepositoryListByOrgOptions{
+		ListOptions: github.ListOptions{},
+	}
 
 	var allRepos []*github.Repository
 


### PR DESCRIPTION
## Description

This PR "migrates" the used version (without any upgrade) for checkout action to SHA. NO upgrade is done.
The SHA values can be found [here](https://github.com/actions/checkout/releases)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files